### PR TITLE
DDP: ESP-IDF support, quick RGBW fix, and active sensor

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -88,6 +88,7 @@ light:
           brightness_scaling: none
           active_sensor: true
 ```
+> **NOTE**: The [NeoPixelBus](https://esphome.io/components/light/neopixelbus/) component does not currently work with the ESP-IDF Framework. Instead, you can use the [ESP32 RMT LED Strip](https://esphome.io/components/light/esp32_rmt_led_strip/) or [SPI LED Strip Light](https://esphome.io/components/light/spi_led_strip/) components.
 
 (4)  Activate the effect.  The effects can be enabled by turning on the light in Home Assistant and then selecting the effect from the light entity's information popup as below:
 

--- a/components/README.md
+++ b/components/README.md
@@ -35,7 +35,7 @@ external_components:
 (2) Invoke the ddp component by adding `ddp:` at the top level of your yaml file.  Top level means that `ddp:` is at the beginning of its line and not tabbed over at all.  This can be seen in the first line of both examples below.
 
 Optional ddp component configuration:
-- **stats_interval** (*Optional*, [Time](https://esphome.io/guides/configuration-types.html#config-time)): Log debug stats (packets/sec, last packet size, source) wih the specified interval. Defaults to `0s` which disables stats collection/logging.
+- **stats_interval** (*Optional*, [Time](https://esphome.io/guides/configuration-types.html#config-time)): Log debug stats (packets/sec, last packet size, source) with the specified interval. Defaults to `0s` which disables stats collection/logging.
 
 (3) Add either ddp or addressable_ddp as an effect to any light entity.  The ddp effect is for single lights such as bulbs.  The addressable_ddp effect is for addressable lights such as RGB strips.
 

--- a/components/README.md
+++ b/components/README.md
@@ -34,6 +34,9 @@ external_components:
 
 (2) Invoke the ddp component by adding `ddp:` at the top level of your yaml file.  Top level means that `ddp:` is at the beginning of its line and not tabbed over at all.  This can be seen in the first line of both examples below.
 
+Optional ddp component configuration:
+- **stats_interval** (*Optional*, [Time](https://esphome.io/guides/configuration-types.html#config-time)): Log debug stats (packets/sec, last packet size, source) wih the specified interval. Defaults to `0s` which disables stats collection/logging.
+
 (3) Add either ddp or addressable_ddp as an effect to any light entity.  The ddp effect is for single lights such as bulbs.  The addressable_ddp effect is for addressable lights such as RGB strips.
 
 Either effect can optionally utilize the following configuration variables:

--- a/components/README.md
+++ b/components/README.md
@@ -46,6 +46,7 @@ Either effect can optionally utilize the following configuration variables:
   - `PIXEL` - Each pixel will individually be scaled up or down to the brightness of the Home Assistant light entity.
   - `STRIP` - Each strip will be scaled up or down so that the brightest pixel of the strip is at the brightness of the Home Assistant light entity.  `PIXEL` and `STRIP` are the same for bulbs.
   - `PACKET` - Each entire packet will be scaled so that the brightest pixel of the packet is at the brightness of the Home Assistant light entity.  `PACKET` and `STRIP` are the same for devices with one LED strip.  
+- **active_sensor** (*Optional*, addressable_ddp only, boolean or mapping): Creates a binary sensor to show if the Addressable DDP effect is actively driving the output (ON) or if no DDP packets have been received and the state is reverted to the ESPHome/Home Assistant color (OFF - after optional timeout above). Set to `true` to create the binary sensor, or set to a mapping with `name: My Custom Sensor Name` to customize the name of the sensor. 
 
 DDP example:
 
@@ -85,6 +86,7 @@ light:
           timeout: 10s
           disable_gamma: true
           brightness_scaling: none
+          active_sensor: true
 ```
 
 (4)  Activate the effect.  The effects can be enabled by turning on the light in Home Assistant and then selecting the effect from the light entity's information popup as below:

--- a/components/ddp/__init__.py
+++ b/components/ddp/__init__.py
@@ -1,13 +1,54 @@
 import esphome.codegen as cg
+from esphome.config_helpers import filter_source_files_from_platform
 import esphome.config_validation as cv
+from esphome.components import binary_sensor
 from esphome.components.light.types import AddressableLightEffect, LightEffect
 from esphome.components.light.effects import (
     register_addressable_effect,
     register_rgb_effect,
 )
-from esphome.const import CONF_ID, CONF_NAME
+from esphome.const import (
+    CONF_ID,
+    CONF_NAME,
+    PLATFORM_BK72XX,
+    PLATFORM_ESP32,
+    PLATFORM_ESP8266,
+    PLATFORM_LN882X,
+    PLATFORM_RTL87XX,
+    PlatformFramework,
+)
+from esphome.core import CORE
+
+
+def AUTO_LOAD() -> list[str]:
+    auto_load = []
+    if CORE.using_esp_idf:
+        auto_load.append("socket")
+    return auto_load
+
 
 DEPENDENCIES = ["network"]
+
+
+def _consume_ddp_sockets(config):
+    if CORE.using_esp_idf:
+        from esphome.components import socket
+
+        socket.consume_sockets(1, "ddp")(config)
+    return config
+
+
+def _normalize_active_sensor(config):
+    active_sensor = config.get(CONF_ACTIVE_SENSOR, False)
+    if active_sensor is False:
+        return config
+    if active_sensor is True:
+        active_sensor = {}
+    if CONF_NAME not in active_sensor:
+        active_sensor = {**active_sensor, CONF_NAME: f"{config[CONF_NAME]} Active"}
+    active_sensor = binary_sensor.binary_sensor_schema(binary_sensor.BinarySensor)(active_sensor)
+    config[CONF_ACTIVE_SENSOR] = active_sensor
+    return config
 
 ddp_ns = cg.esphome_ns.namespace("ddp")
 DDPLightEffect = ddp_ns.class_("DDPLightEffect", LightEffect)
@@ -27,6 +68,7 @@ CONF_DDP_ID = "ddp_id"
 CONF_DDP_TIMEOUT = "timeout"
 CONF_DDP_DIS_GAMMA = "disable_gamma"
 CONF_DDP_SCALING = "brightness_scaling"
+CONF_ACTIVE_SENSOR = "active_sensor"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
@@ -34,7 +76,16 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(DDPComponent),
         }
     ),
-    cv.only_with_arduino,
+    cv.only_on(
+        [
+            PLATFORM_ESP32,
+            PLATFORM_ESP8266,
+            PLATFORM_BK72XX,
+            PLATFORM_LN882X,
+            PLATFORM_RTL87XX,
+        ]
+    ),
+    _consume_ddp_sockets,
 )
 
 
@@ -63,7 +114,12 @@ async def to_code(config):
         cv.Optional(CONF_DDP_TIMEOUT): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_DDP_DIS_GAMMA): cv.boolean,
         cv.Optional(CONF_DDP_SCALING): cv.one_of(*DDP_SCALING, upper=True),
+        cv.Optional(CONF_ACTIVE_SENSOR, default=False): cv.Any(
+            cv.boolean,
+            cv.Schema({}, extra=cv.ALLOW_EXTRA),
+        ),
     },
+    _normalize_active_sensor,
 )
 async def ddp_light_effect_to_code(config, effect_id):
     parent = await cg.get_variable(config[CONF_DDP_ID])
@@ -81,4 +137,22 @@ async def ddp_light_effect_to_code(config, effect_id):
     if CONF_DDP_SCALING in config:
         cg.add(effect.set_scaling_mode(DDP_SCALING[config[CONF_DDP_SCALING]]))
 
+    if config.get(CONF_ACTIVE_SENSOR):
+        sensor = await binary_sensor.new_binary_sensor(config[CONF_ACTIVE_SENSOR])
+        cg.add(effect.set_effect_active_sensor(sensor))
+
     return effect
+
+
+FILTER_SOURCE_FILES = filter_source_files_from_platform(
+    {
+        "ddp_arduino.cpp": {
+            PlatformFramework.ESP32_ARDUINO,
+            PlatformFramework.ESP8266_ARDUINO,
+            PlatformFramework.BK72XX_ARDUINO,
+            PlatformFramework.RTL87XX_ARDUINO,
+            PlatformFramework.LN882X_ARDUINO,
+        },
+        "ddp_esp32_idf.cpp": {PlatformFramework.ESP32_IDF},
+    }
+)

--- a/components/ddp/__init__.py
+++ b/components/ddp/__init__.py
@@ -69,11 +69,15 @@ CONF_DDP_TIMEOUT = "timeout"
 CONF_DDP_DIS_GAMMA = "disable_gamma"
 CONF_DDP_SCALING = "brightness_scaling"
 CONF_ACTIVE_SENSOR = "active_sensor"
+CONF_STATS_INTERVAL = "stats_interval"
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(DDPComponent),
+            cv.Optional(
+                CONF_STATS_INTERVAL, default="0s"
+            ): cv.positive_time_period_milliseconds,
         }
     ),
     cv.only_on(
@@ -92,6 +96,7 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+    cg.add(var.set_stats_interval(config[CONF_STATS_INTERVAL]))
 
 
 @register_rgb_effect(

--- a/components/ddp/ddp.cpp
+++ b/components/ddp/ddp.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "ddp.h"
 #include "ddp_light_effect_base.h"
@@ -8,72 +8,16 @@ namespace esphome {
 namespace ddp {
 
 static const char *const TAG = "ddp";
-static const int PORT = 4048;
 
 DDPComponent::DDPComponent() {}
 DDPComponent::~DDPComponent() {}
 void DDPComponent::setup() {}
 
-void DDPComponent::loop() {
-
-  if ( !this->udp_ ) { return; }
-
-  std::vector<uint8_t> payload;
-
-  while (uint16_t packet_size = this->udp_->parsePacket()) {
-    payload.resize(packet_size);
-
-    if (!this->udp_->read(&payload[0], payload.size())) {
-      continue;
-    }
-
-    if (!this->process_(&payload[0], payload.size())) {
-      continue;
-    }
-
-  }
-}
-
-void DDPComponent::add_effect(DDPLightEffectBase *light_effect) {
-
-  if (light_effects_.count(light_effect)) {
-    return;
-  }
-
-  // only the first effect added needs to start udp listening
-  // but we still need to add the effect to the set so it can be applied.
-  if (this->light_effects_.size() == 0) {
-    if (!this->udp_) { this->udp_ = make_unique<WiFiUDP>(); }
-
-    ESP_LOGD(TAG, "Starting UDP listening for DDP.");
-    if (!this->udp_->begin(PORT)) {
-      ESP_LOGE(TAG, "Cannot bind DDP to port %d.", PORT);
-      mark_failed();
-      return;
-    }
-  }
-
-  this->light_effects_.insert(light_effect);
-}
-
-void DDPComponent::remove_effect(DDPLightEffectBase *light_effect) {
-
-  if (!this->light_effects_.count(light_effect)) { return; }
-
-  this->light_effects_.erase(light_effect);
-
-  // if no more effects left, stop udp listening
-  if ( (this->light_effects_.size() == 0) && this->udp_) {
-    ESP_LOGD(TAG, "Stopping UDP listening for DDP.");
-    this->udp_->stop();
-  }
-}
-
 bool DDPComponent::process_(const uint8_t *payload, uint16_t size) {
 
   // size under 10 means we don't even receive a valid header.
   // size under 13 means we don't have enough for even 1 pixel.
-  if ( size < 13 ){
+  if (size < 13) {
     ESP_LOGE(TAG, "Invalid DDP packet received, too short (size=%d)", size);
     return false;
   }
@@ -81,12 +25,15 @@ bool DDPComponent::process_(const uint8_t *payload, uint16_t size) {
   // ignore packet if data offset != [00 00 00 00].  This likely means the device is receiving a DDP packet not meant for it.
   // There may be a better way to handle this header field.  One user was receiving packets with non-zero data offset that were
   // screwing up the light effect (flickering).
-  if ( payload[4] || payload[5] || payload[6] || payload[7] ) {
+  if (payload[4] || payload[5] || payload[6] || payload[7]) {
     ESP_LOGE(TAG, "Ignoring DDP Packet with non-zero data offset.");
     return false;
   }
 
-  ESP_LOGV(TAG, "DDP packet received (size=%d): - %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x [%02x %02x %02x]", size, payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6], payload[7], payload[8], payload[9], payload[10], payload[11], payload[12] );
+  ESP_LOGV(TAG,
+           "DDP packet received (size=%d): - %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x [%02x %02x %02x]",
+           size, payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6], payload[7], payload[8],
+           payload[9], payload[10], payload[11], payload[12]);
 
   // first 10 bytes are the header, so consider them used from the get-go
   // if timecode field is used, takes up an additional 4 bytes of header.
@@ -98,10 +45,15 @@ bool DDPComponent::process_(const uint8_t *payload, uint16_t size) {
 
   // run through all registered effects, each takes required data per their size starting at packet address determined by used.
   for (auto *light_effect : this->light_effects_) {
-    if ( used >= size ) { return false; }
-    uint16_t new_used = light_effect->process_(&payload[0], size, used);
-    if (new_used == 0)  { return false; }
-    else                { used += new_used; }
+    if (used >= size) {
+      return false;
+    }
+    uint16_t new_used = light_effect->process_(payload, size, used);
+    if (new_used == 0) {
+      return false;
+    } else {
+      used += new_used;
+    }
   }
 
   return true;
@@ -110,4 +62,4 @@ bool DDPComponent::process_(const uint8_t *payload, uint16_t size) {
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp.h
+++ b/components/ddp/ddp.h
@@ -45,6 +45,11 @@ class DDPComponent : public esphome::Component {
 
   void add_effect(DDPLightEffectBase *light_effect);
   void remove_effect(DDPLightEffectBase *light_effect);
+  void set_stats_interval(uint32_t interval_ms) {
+    this->stats_interval_ms_ = interval_ms;
+    this->stats_last_ms_ = 0;
+    this->stats_packets_ = 0;
+  }
 
  protected:
 #ifdef USE_ARDUINO
@@ -56,6 +61,14 @@ class DDPComponent : public esphome::Component {
   std::set<DDPLightEffectBase *> light_effects_;
 
   bool process_(const uint8_t *payload, uint16_t size);
+  void note_packet_(const char *source, uint16_t size);
+
+  uint32_t stats_interval_ms_{0};
+  uint32_t stats_last_ms_{0};
+  uint32_t stats_packets_{0};
+  uint16_t last_packet_size_{0};
+  char last_source_[64]{};
+  bool have_source_{false};
 };
 
 }  // namespace ddp

--- a/components/ddp/ddp.h
+++ b/components/ddp/ddp.h
@@ -1,9 +1,10 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "esphome/core/component.h"
 
+#ifdef USE_ARDUINO
 #ifdef USE_ESP32
 #include <WiFi.h>
 #endif
@@ -16,6 +17,11 @@
 #ifdef USE_LIBRETINY
 #include <WiFi.h>
 #include <WiFiUdp.h>
+#endif
+#endif  // USE_ARDUINO
+
+#ifdef USE_ESP_IDF
+#include "esphome/components/socket/socket.h"
 #endif
 
 #include <map>
@@ -41,7 +47,12 @@ class DDPComponent : public esphome::Component {
   void remove_effect(DDPLightEffectBase *light_effect);
 
  protected:
+#ifdef USE_ARDUINO
   std::unique_ptr<WiFiUDP> udp_;
+#endif
+#ifdef USE_ESP_IDF
+  std::unique_ptr<socket::Socket> socket_;
+#endif
   std::set<DDPLightEffectBase *> light_effects_;
 
   bool process_(const uint8_t *payload, uint16_t size);
@@ -50,4 +61,4 @@ class DDPComponent : public esphome::Component {
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_addressable_light_effect.cpp
+++ b/components/ddp/ddp_addressable_light_effect.cpp
@@ -1,8 +1,11 @@
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "ddp.h"
 #include "ddp_addressable_light_effect.h"
 #include "esphome/core/log.h"
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
 
 namespace esphome {
 namespace ddp {
@@ -12,6 +15,15 @@ static const char *const TAG = "ddp_addressable_light_effect";
 DDPAddressableLightEffect::DDPAddressableLightEffect(const char *name) : AddressableLightEffect(name) {}
 
 const char *DDPAddressableLightEffect::get_name() { return AddressableLightEffect::get_name(); }
+
+#ifdef USE_BINARY_SENSOR
+void DDPAddressableLightEffect::set_effect_active_sensor(binary_sensor::BinarySensor *sensor) {
+  this->effect_active_sensor_ = sensor;
+  if (this->effect_active_sensor_ != nullptr) {
+    this->effect_active_sensor_->publish_state(false);
+  }
+}
+#endif
 
 void DDPAddressableLightEffect::start() {
 
@@ -23,7 +35,7 @@ void DDPAddressableLightEffect::start() {
   DDPLightEffectBase::start();
 
   // not automatically active just because enabled
-  this->get_addressable_()->set_effect_active(false);
+  this->set_effect_active_(this->get_addressable_(), false);
 
 }
 
@@ -31,9 +43,11 @@ void DDPAddressableLightEffect::stop() {
 
   // restore backed up gamma value and recalculate gamma table.
   this->state_->set_gamma_correct(this->gamma_backup_);
-  this->get_addressable_()->setup_state(this->state_);
+  auto *it = this->get_addressable_();
+  it->setup_state(this->state_);
   this->next_packet_will_be_first_ = true;
 
+  this->set_effect_active_(it, false);
   DDPLightEffectBase::stop();
   AddressableLightEffect::stop();
 }
@@ -68,7 +82,7 @@ void DDPAddressableLightEffect::apply(light::AddressableLight &it, const Color &
     it.setup_state(this->state_);
 
     // effect no longer active
-    it.set_effect_active(false);
+    this->set_effect_active_(&it, false);
 
     call.perform();
    }
@@ -92,7 +106,7 @@ uint16_t DDPAddressableLightEffect::process_(const uint8_t *payload, uint16_t si
   auto *it = this->get_addressable_();
 
   // effect is active once a ddp packet is received.
-  it->set_effect_active(true);
+  this->set_effect_active_(it, true);
 
 
 #ifdef USE_ESP32
@@ -163,9 +177,9 @@ uint16_t DDPAddressableLightEffect::process_(const uint8_t *payload, uint16_t si
         break;
     }
 
-    // assign pixel color
+    // assign pixel color; clear white channel for RGBW strips
     auto output = (*it)[(i-used)/3];
-    output.set_rgb(red, green, blue);
+    output.set_rgbw(red, green, blue, 0);
   }
 
   it->schedule_show();
@@ -199,7 +213,19 @@ void DDPAddressableLightEffect::set_max_brightness_() {
   this->get_addressable_()->update_state(this->state_);
 }
 
+void DDPAddressableLightEffect::set_effect_active_(light::AddressableLight *it, bool active) {
+  if (it == nullptr) {
+    return;
+  }
+  it->set_effect_active(active);
+#ifdef USE_BINARY_SENSOR
+  if (this->effect_active_sensor_ != nullptr) {
+    this->effect_active_sensor_->publish_state(active);
+  }
+#endif
+}
+
 }  // namespace e131
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_addressable_light_effect.cpp
+++ b/components/ddp/ddp_addressable_light_effect.cpp
@@ -225,7 +225,7 @@ void DDPAddressableLightEffect::set_effect_active_(light::AddressableLight *it, 
 #endif
 }
 
-}  // namespace e131
+}  // namespace ddp
 }  // namespace esphome
 
 #endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_addressable_light_effect.h
+++ b/components/ddp/ddp_addressable_light_effect.h
@@ -1,10 +1,16 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/addressable_light_effect.h"
 #include "ddp_light_effect_base.h"
+
+namespace esphome {
+namespace binary_sensor {
+class BinarySensor;
+}  // namespace binary_sensor
+}  // namespace esphome
 
 namespace esphome {
 namespace ddp {
@@ -20,16 +26,24 @@ class DDPAddressableLightEffect : public DDPLightEffectBase, public light::Addre
 
   void apply(light::AddressableLight &it, const Color &current_color) override;
 
+#ifdef USE_BINARY_SENSOR
+  void set_effect_active_sensor(binary_sensor::BinarySensor *sensor);
+#endif
+
  protected:
   uint16_t process_(const uint8_t *payload, uint16_t size, uint16_t used) override;
 
   float scan_packet_and_return_multiplier_(const uint8_t *payload, uint16_t start, uint16_t end);
   float multiplier_from_max_val_(uint8_t max_val);
   void set_max_brightness_();
+  void set_effect_active_(light::AddressableLight *it, bool active);
 
+#ifdef USE_BINARY_SENSOR
+  binary_sensor::BinarySensor *effect_active_sensor_{nullptr};
+#endif
 };
 
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_arduino.cpp
+++ b/components/ddp/ddp_arduino.cpp
@@ -46,7 +46,7 @@ void DDPComponent::add_effect(DDPLightEffectBase *light_effect) {
 
   // only the first effect added needs to start udp listening
   // but we still need to add the effect to the set so it can be applied.
-  if (this->light_effects_.size() == 0) {
+  if (this->light_effects_.empty()) {
     if (!this->udp_) { this->udp_ = make_unique<WiFiUDP>(); }
 
     ESP_LOGD(TAG, "Starting UDP listening for DDP.");
@@ -67,7 +67,7 @@ void DDPComponent::remove_effect(DDPLightEffectBase *light_effect) {
   this->light_effects_.erase(light_effect);
 
   // if no more effects left, stop udp listening
-  if ( (this->light_effects_.size() == 0) && this->udp_) {
+  if ( (this->light_effects_.empty()) && this->udp_) {
     ESP_LOGD(TAG, "Stopping UDP listening for DDP.");
     this->udp_->stop();
   }

--- a/components/ddp/ddp_arduino.cpp
+++ b/components/ddp/ddp_arduino.cpp
@@ -1,0 +1,70 @@
+#ifdef USE_ARDUINO
+
+#include "ddp.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace ddp {
+
+static const char *const TAG = "ddp";
+static const int PORT = 4048;
+
+void DDPComponent::loop() {
+
+  if ( !this->udp_ ) { return; }
+
+  std::vector<uint8_t> payload;
+
+  while (uint16_t packet_size = this->udp_->parsePacket()) {
+    payload.resize(packet_size);
+
+    if (!this->udp_->read(&payload[0], payload.size())) {
+      continue;
+    }
+
+    if (!this->process_(&payload[0], payload.size())) {
+      continue;
+    }
+
+  }
+}
+
+void DDPComponent::add_effect(DDPLightEffectBase *light_effect) {
+
+  if (light_effects_.count(light_effect)) {
+    return;
+  }
+
+  // only the first effect added needs to start udp listening
+  // but we still need to add the effect to the set so it can be applied.
+  if (this->light_effects_.size() == 0) {
+    if (!this->udp_) { this->udp_ = make_unique<WiFiUDP>(); }
+
+    ESP_LOGD(TAG, "Starting UDP listening for DDP.");
+    if (!this->udp_->begin(PORT)) {
+      ESP_LOGE(TAG, "Cannot bind DDP to port %d.", PORT);
+      mark_failed();
+      return;
+    }
+  }
+
+  this->light_effects_.insert(light_effect);
+}
+
+void DDPComponent::remove_effect(DDPLightEffectBase *light_effect) {
+
+  if (!this->light_effects_.count(light_effect)) { return; }
+
+  this->light_effects_.erase(light_effect);
+
+  // if no more effects left, stop udp listening
+  if ( (this->light_effects_.size() == 0) && this->udp_) {
+    ESP_LOGD(TAG, "Stopping UDP listening for DDP.");
+    this->udp_->stop();
+  }
+}
+
+}  // namespace ddp
+}  // namespace esphome
+
+#endif  // USE_ARDUINO

--- a/components/ddp/ddp_arduino.cpp
+++ b/components/ddp/ddp_arduino.cpp
@@ -3,6 +3,8 @@
 #include "ddp.h"
 #include "esphome/core/log.h"
 
+#include <cstdio>
+
 namespace esphome {
 namespace ddp {
 
@@ -26,6 +28,13 @@ void DDPComponent::loop() {
       continue;
     }
 
+    if (this->stats_interval_ms_ != 0) {
+      IPAddress ip = this->udp_->remoteIP();
+      uint16_t port = this->udp_->remotePort();
+      char source[32];
+      snprintf(source, sizeof(source), "%u.%u.%u.%u:%u", ip[0], ip[1], ip[2], ip[3], port);
+      this->note_packet_(source, static_cast<uint16_t>(payload.size()));
+    }
   }
 }
 

--- a/components/ddp/ddp_esp32_idf.cpp
+++ b/components/ddp/ddp_esp32_idf.cpp
@@ -1,0 +1,105 @@
+#ifdef USE_ESP_IDF
+
+#include "ddp.h"
+#include "esphome/core/log.h"
+
+#include <lwip/sockets.h>
+
+#include <array>
+#include <cerrno>
+
+namespace esphome {
+namespace ddp {
+
+static const char *const TAG = "ddp";
+static const int PORT = 4048;
+
+void DDPComponent::loop() {
+  if (this->socket_ == nullptr || !this->socket_->ready()) { return; }
+
+  int fd = this->socket_->get_fd();
+  if (fd < 0) {
+    return;
+  }
+
+  static constexpr size_t kMaxPacketSize = 1500;
+  std::array<uint8_t, kMaxPacketSize> payload{};
+
+  while (this->socket_ != nullptr && this->socket_->ready()) {
+    struct sockaddr_storage client_addr = {};
+    socklen_t addr_len = sizeof(client_addr);
+    ssize_t len =
+        recvfrom(fd, payload.data(), payload.size(), MSG_DONTWAIT, (struct sockaddr *) &client_addr, &addr_len);
+    if (len < 0) {
+      if (errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+        ESP_LOGW(TAG, "recvfrom failed: %d", errno);
+      }
+      return;
+    }
+    if (len == 0) {
+      return;
+    }
+
+    if (!this->process_(payload.data(), static_cast<uint16_t>(len))) {
+      continue;
+    }
+  }
+}
+
+void DDPComponent::add_effect(DDPLightEffectBase *light_effect) {
+  if (light_effects_.count(light_effect)) {
+    return;
+  }
+
+  // only the first effect added needs to start udp listening
+  // but we still need to add the effect to the set so it can be applied.
+  if (this->light_effects_.empty()) {
+    if (this->socket_ == nullptr) {
+      this->socket_ = socket::socket_ip_loop_monitored(SOCK_DGRAM, IPPROTO_UDP);
+    }
+    if (this->socket_ == nullptr) {
+      ESP_LOGE(TAG, "Socket create failed");
+      mark_failed();
+      return;
+    }
+
+    int enable = 1;
+    this->socket_->setsockopt(SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable));
+
+    struct sockaddr_storage server_addr = {};
+    socklen_t addr_len =
+        socket::set_sockaddr_any((struct sockaddr *) &server_addr, sizeof(server_addr), PORT);
+
+    int err = this->socket_->bind((struct sockaddr *) &server_addr, addr_len);
+    if (err != 0) {
+      ESP_LOGE(TAG, "Cannot bind DDP to port %d (err=%d).", PORT, errno);
+      this->socket_ = nullptr;
+      mark_failed();
+      return;
+    }
+
+    ESP_LOGD(TAG, "Starting UDP listening for DDP.");
+  }
+
+  this->light_effects_.insert(light_effect);
+}
+
+void DDPComponent::remove_effect(DDPLightEffectBase *light_effect) {
+  if (!this->light_effects_.count(light_effect)) {
+    return;
+  }
+
+  this->light_effects_.erase(light_effect);
+
+  // if no more effects left, stop udp listening
+  if (this->light_effects_.empty() && this->socket_ != nullptr) {
+    ESP_LOGD(TAG, "Stopping UDP listening for DDP.");
+    this->socket_->close();
+    this->socket_ = nullptr;
+  }
+}
+
+}  // namespace ddp
+}  // namespace esphome
+
+#endif  // USE_ESP_IDF

--- a/components/ddp/ddp_light_effect.cpp
+++ b/components/ddp/ddp_light_effect.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "ddp.h"
 #include "ddp_light_effect.h"
@@ -152,4 +152,4 @@ uint16_t DDPLightEffect::process_(const uint8_t *payload, uint16_t size, uint16_
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_light_effect.h
+++ b/components/ddp/ddp_light_effect.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/light_effect.h"
@@ -27,4 +27,4 @@ class DDPLightEffect : public DDPLightEffectBase, public light::LightEffect {
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // ESPHOME_DDP_LIGHT_EFFECT_H
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_light_effect_base.cpp
+++ b/components/ddp/ddp_light_effect_base.cpp
@@ -1,4 +1,4 @@
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "ddp.h"
 #include "ddp_light_effect_base.h"
@@ -40,4 +40,4 @@ bool DDPLightEffectBase::timeout_check() {
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF

--- a/components/ddp/ddp_light_effect_base.h
+++ b/components/ddp/ddp_light_effect_base.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#ifdef USE_ARDUINO
+#if defined(USE_ARDUINO) || defined(USE_ESP_IDF)
 
 #include "esphome/core/component.h"
 #include "esphome/components/light/light_effect.h"
@@ -52,4 +52,4 @@ class DDPLightEffectBase {
 }  // namespace ddp
 }  // namespace esphome
 
-#endif  // USE_ARDUINO
+#endif  // USE_ARDUINO || USE_ESP_IDF


### PR DESCRIPTION
Thank you for making this DDP component — I use it all the time! 

The only drawbacks I ran into were the Arduino framework requirement and color issues with RGBW strips. 

### Changes:

- Refactored DDP component to support both Arduino and ESP-IDF platforms by splitting UDP/socket handling into separate files
- Clear white channel for RGBW strips
  - Allows RGB colors to be accurately displayed on RGBW strips
  - NOT full RGBW support
- Added `active_sensor` to optionally create a binary sensor that reflects effect activity
  - Useful for automations (e.g., my strips turn on/off with presence detection, but I want them always on while broadcasting DDP)
- Updated documentation

### Testing:
Unfortunately, I have a limited scope of devices with which to test. I have several of your plugs, but none of your bulbs... yet. 
- ESPHome 2025.12.3
- LedFX (https://github.com/LedFx/LedFx)
- ESP32-P4 and ESP32-S3 devices
- RGB and RGBW strips
- Recommended versions of the Arduino (3.3.2) and ESP-IDF (5.5.1) Frameworks
